### PR TITLE
Dockerize this repository for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ ENV APACHE_RUN_USER=www-data APACHE_RUN_GROUP=www-data APACHE_LOG_DIR=/var/log/a
 ENV TZ=America/New_York
 # timezone: https://serverfault.com/a/683651/456938
 RUN apt-get update && \
-  apt-get -qq -y install apt-utils git tzdata apache2 php libapache2-mod-php php-mcrypt php-mysql curl && \
+  apt-get -qq -y install apt-utils git tzdata apache2 php libapache2-mod-php php-mysql curl && \
   ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 COPY . /var/www/html/
 WORKDIR /var/www/html/
-RUN curl -sL https://github.com/EnvironmentalDashboard/calendar/archive/master.tar.gz | tar xz && mv calendar-master calendar && \
+RUN curl -sL https://github.com/EnvironmentalDashboard/calendar.archived/archive/master.tar.gz | tar xz && mv calendar.archived-master calendar && \
 curl -sL https://github.com/EnvironmentalDashboard/buildingnavigation/archive/master.tar.gz | tar xz && mv buildingnavigation-master buildingnavigation && \
 curl -sL https://github.com/EnvironmentalDashboard/chart/archive/master.tar.gz | tar xz && mv chart-master chart && \
 curl -sL https://github.com/EnvironmentalDashboard/GoogleDriveAPI/archive/master.tar.gz | tar xz && mv GoogleDriveAPI-master GoogleDriveAPI && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,5 @@
-# production, sealed off container
-
-FROM ubuntu
-ENV DEBIAN_FRONTEND=noninteractive
-ENV APACHE_RUN_USER=www-data APACHE_RUN_GROUP=www-data APACHE_LOG_DIR=/var/log/apache2 APACHE_LOCK_DIR=/var/lock/apache2 APACHE_PID_FILE=/var/run/apache2.pid
-ENV TZ=America/New_York
-# timezone: https://serverfault.com/a/683651/456938
-RUN apt-get update && \
-  apt-get -qq -y install apt-utils git tzdata apache2 php libapache2-mod-php php-mysql curl && \
-  ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-COPY . /var/www/html/
-WORKDIR /var/www/html/
-RUN curl -sL https://github.com/EnvironmentalDashboard/calendar.archived/archive/master.tar.gz | tar xz && mv calendar.archived-master calendar && \
-curl -sL https://github.com/EnvironmentalDashboard/buildingnavigation/archive/master.tar.gz | tar xz && mv buildingnavigation-master buildingnavigation && \
-curl -sL https://github.com/EnvironmentalDashboard/chart/archive/master.tar.gz | tar xz && mv chart-master chart && \
-curl -sL https://github.com/EnvironmentalDashboard/GoogleDriveAPI/archive/master.tar.gz | tar xz && mv GoogleDriveAPI-master GoogleDriveAPI && \
-curl -sL https://github.com/EnvironmentalDashboard/search/archive/master.tar.gz | tar xz && mv search-master search && \
-curl -sL https://github.com/EnvironmentalDashboard/includes/archive/master.tar.gz | tar xz && mv includes-master includes && \
-curl -sL https://github.com/EnvironmentalDashboard/citywide-dashboard/archive/master.tar.gz | tar xz && mv citywide-dashboard-master citywide-dashboard && \
-curl -sL https://github.com/EnvironmentalDashboard/prefs/archive/master.tar.gz | tar xz && mv prefs-master prefs && \
-curl -sL https://github.com/EnvironmentalDashboard/gauges/archive/master.tar.gz | tar xz && mv gauges-master gauges
-EXPOSE 80
-CMD /usr/sbin/apache2ctl -D FOREGROUND
-# to run:
-# docker build -t prod-site .
-# docker run -dit -p 80:80 --name environmentaldashboard.org prod-site
+FROM php:7.2-apache
+COPY . /var/www/html
+COPY ./apache/httpd.conf /etc/apache2/sites-enabled
+RUN a2enmod rewrite
+RUN a2dissite 000-default.conf

--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
 # environmentaldashboard.org
 
+Below contains the original README.
+But, a note:
+In November, 2019, this was Dockerized to allow for easier local development
+on just this repository independently.
+To use this method of development, run:
+`./build.sh`, then `./run.sh`.
+
+If you are looking for more technical documentation, check out the paragraph
+below.
+
 This repository contains the environmentaldashboard.org website. However, there are few files here other than the static pages of the website (the landing page, the gauges explained page, etc.) and stylesheets. All of the dynamic components of the website are maintained as seperate repositories to encourage modular applications which can be adopted as standalone websites. For example, if you were to clone this repository, the landing page would work because it only has static content, but navigating to the calendar would generate a 404 error because the calendar is a seperate repository which must be cloned seperately and symlinked into this repository (the name of the symlink will become the URL). The calendar application looks at the URL it is being run at (via `$_SERVER['SCRIPT_FILENAME']` and _not_ `__DIR__` or something like that because symlinks need to be resolved) to determine the correct stylesheets, js, etc. to serve along with the HTML.
 

--- a/apache/httpd.conf
+++ b/apache/httpd.conf
@@ -1,0 +1,9 @@
+<VirtualHost *:80>
+  RewriteEngine On
+
+  <Directory /var/www/>
+    		# remove .php
+		RewriteCond %{REQUEST_FILENAME}.php -f
+		RewriteRule !.*\.php$ %{REQUEST_FILENAME}.php [QSA,L]
+  </Directory>
+</VirtualHost>

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,1 @@
+docker build -t edorg .

--- a/run.sh
+++ b/run.sh
@@ -1,1 +1,1 @@
-docker run -dit -p 3002:80 --restart always -v /Users/sam/Documents/Programming/EnvironmentalDashboard/environmentaldashboard.org:/var/www/html --name EDORG edorg
+docker run -dit -p 3003:80 --restart always -v /Users/sam/Documents/Programming/EnvironmentalDashboard/environmentaldashboard.org:/var/www/html --name EDORG edorg

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,1 @@
+docker run -dit -p 3002:80 --restart always -v /Users/sam/Documents/Programming/EnvironmentalDashboard/environmentaldashboard.org:/var/www/html --name EDORG edorg

--- a/run.sh
+++ b/run.sh
@@ -1,1 +1,1 @@
-docker run -dit -p 3003:80 --restart always -v /Users/sam/Documents/Programming/EnvironmentalDashboard/environmentaldashboard.org:/var/www/html --name EDORG edorg
+docker run -dit -p 3003:80 --restart always -v $(pwd):/var/www/html --name EDORG edorg


### PR DESCRIPTION
Trello: https://trello.com/c/WIxmczPW/99-set-up-environmentaldashboardorg-docker-development-for-oliver

This pull request provides our usual pattern of files for running a Docker environment, a `Dockerfile`, `build.sh` and `run.sh`, so that this can be developed locally more easily.

@oliverripps can you try the instructions in the README?  The server will run on port 3003.  This will allow you to develop without the weird hacky way that I showed you.

@Terf Are you okay with this using the PHP Docker image so that less code is needed?  I really like the clean 5-line Dockerfile.